### PR TITLE
Use scikit kmeans clustering instead of pycluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ URF (Unsupervised Random Forest, or Random Forest Clustering) is a python implem
 ## Installation
 
 ```shell
-pip install URF
+git clone https://github.com/mtanghu/URF.git
+cd URF
+pip install .
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ URF (Unsupervised Random Forest, or Random Forest Clustering) is a python implem
 ## Installation
 
 ```shell
-git clone https://github.com/mtanghu/URF.git
-cd URF
-pip install .
+pip install URF
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 URF (Unsupervised Random Forest, or Random Forest Clustering) is a python implementation of the paper: Shi, T., & Horvath, S. (2006). Unsupervised learning with random forest predictors. *Journal of Computational and Graphical Statistics*, 15(1), 118-138.
 
-## Prerequisite
-
-```shell
-conda install -c bioconda pycluster
-```
-
-or
-
-```shell
-wget http://bonsai.hgc.jp/~mdehoon/software/cluster/Pycluster-1.54.tar.gz
-tar -zxvf Pycluster-1.54.tar.gz
-cd Pycluster-1.54
-python setup.py install
-```
 
 ## Installation
 

--- a/URF/main.py
+++ b/URF/main.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.manifold import MDS
 import matplotlib.pyplot as plt
-from Pycluster import kcluster
+from sklearn.cluster import KMeans
 
 
 def build_synthetic_matrix(X):
@@ -97,7 +97,7 @@ def random_forest_cluster(X, k=2, dissimilarity=True, **kwargs):
 
     if dissimilarity:
         prox_mat = 1 - prox_mat
-    cluster_ids, error, n_found = kcluster(prox_mat, nclusters=k, method="m")
+    cluster_ids, error, n_found = KMeans(n_clusters=k, random_state=kwargs.get("random_state")).fit_predict(X)
 
     return clf, prox_mat, cluster_ids
 

--- a/URF/main.py
+++ b/URF/main.py
@@ -97,7 +97,7 @@ def random_forest_cluster(X, k=2, dissimilarity=True, **kwargs):
 
     if dissimilarity:
         prox_mat = 1 - prox_mat
-    cluster_ids, error, n_found = KMeans(n_clusters=k, random_state=kwargs.get("random_state")).fit_predict(X)
+    cluster_ids = KMeans(n_clusters=k, random_state=kwargs.get("random_state")).fit_predict(prox_mat)
 
     return clf, prox_mat, cluster_ids
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=['scikit-learn>=0.17', 'numpy>=1.9.0', 'scipy', 'pycluster'],
     url='https://github.com/liyao001/URF',
     packages=["URF", ],
+    install_requires=["scikit-learn", ],
     license='Apache 2.0',
     author='Li Yao',
     author_email='yaol17@mails.tsinghua.edu.cn',


### PR DESCRIPTION
Pycluster is more difficult to install (requiring a conda install) and does not have the parallelism that the scikit package does. Scikit is also shown in the example, so this change would be consistent with that.